### PR TITLE
Added "login into host-shell"-mode, scp-into home directory, non-tty-mode, solved minor bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ will give you an interactive shell.
 - [Docker](https://docs.docker.com/install/)
 - [Python 3.x](https://www.python.org/downloads/)
 - [pip](https://pip.pypa.io/en/stable/installing/)
+- [rssh](http://www.pizzashack.org/rssh/)
+
+**To enable scp,rsync,sftp for all users, configure rssh as follows:**
+```
+sudo echo "
+allowscp
+allowsftp
+allowrsync
+" > /etc/rssh.conf
+```
 
 Make sure all `dockersh` users have the [permissions to interact with the Docker daemon](https://docs.docker.com/install/linux/linux-postinstall/).
 

--- a/dockersh
+++ b/dockersh
@@ -123,6 +123,9 @@ def parse_args():
 args = parse_args()
 host_config = cli.create_host_config(binds=[args.home + ':/home/' + user],
                                      restart_policy={'Name' : 'unless-stopped'})
+if os.path.basename(args.cmd.split(" ")[0]).startswith(("scp -p","rsync --server","sftp-server")):
+    os.system("rssh -c \""+args.cmd+"\"")
+    sys.exit(0)
 
 name_passed  = (args.name  != "")
 image_passed = (args.image != "")

--- a/dockersh
+++ b/dockersh
@@ -55,15 +55,6 @@ def image_split(s):
     else:
         return sp[0], sp[1]
 
-def load_ini():
-    cfg = ConfigParser(os.environ, interpolation=ExtendedInterpolation())
-    cfg.read(config_file)
-
-    if cfg.has_section(user):
-        return cfg[user]
-    else:
-        return cfg['DEFAULT']
-
 def selection_menu(choices):
     if len(choices) == 1:
         return 0
@@ -80,7 +71,8 @@ def selection_menu(choices):
 
 #if __name__ == "__main__":
 def parse_args():
-    ini = load_ini()
+
+
 
     parser = argparse.ArgumentParser(prog=prog)
     parser.add_argument('--version',
@@ -119,12 +111,27 @@ def parse_args():
     args.ini = ini
     return args
 
+
+# load ini
+cfg = ConfigParser(os.environ, interpolation=ExtendedInterpolation())
+cfg.read(config_file)
+
+admin_cmd = "admin"
+if cfg.has_section("ADMINS") and "command" in cfg["ADMINS"]["command"]:
+    admin_cmd = cfg["ADMINS"]["command"]
+ini = cfg[user] if cfg.has_section(user) else cfg['DEFAULT']
+
 #if __name__ == "__main__":
 args = parse_args()
+
 host_config = cli.create_host_config(binds=[args.home + ':/home/' + user],
                                      restart_policy={'Name' : 'unless-stopped'})
 if os.path.basename(args.cmd.split(" ")[0]).startswith(("scp -p","rsync --server","sftp-server")):
     os.system("rssh -c \""+args.cmd+"\"")
+    sys.exit(0)
+if args.cmd == admin_cmd:
+    print("Trying to login into host: "+user)
+    os.system("sudo -u "+user+" su - "+user)
     sys.exit(0)
 
 name_passed  = (args.name  != "")

--- a/dockersh
+++ b/dockersh
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
+import os
+os.environ['TERM'] = 'xterm' # removes warning on non-tty commands
 
 import argparse
 #import argcomplete
@@ -8,7 +10,6 @@ from configparser import ConfigParser, ExtendedInterpolation
 import docker
 import random
 import string
-import os
 import sys
 
 prog = 'dockersh'
@@ -98,6 +99,10 @@ def parse_args():
                         action='store_true',
                         help="execute in temporary container",
                         default=False)
+    parser.add_argument('-c', '--command',
+                        dest='cmd',
+                        help="pass command to bash in container",
+                        default="")
     parser.add_argument('--shell',
                         dest='shell',
                         help="shell to start inside the container",
@@ -166,10 +171,11 @@ if len(containers(container_filter=args.name)) == 0:
                          host_config=host_config)
 
 cli.start(args.full_name)
-os.system('cls||clear')
 print(args.greeting)
+cmd = args.cmd if args.cmd else args.shell
 #cli.attach(cfg.name, stream=True) #BUG https://github.com/docker/docker-py/issues/390
-os.system('docker exec -it ' + args.full_name + ' ' + args.shell) #HACK
+docker_arg = "" if not sys.stdout.isatty() else "-it"
+os.system('docker exec ' + docker_arg +' '+ args.full_name + ' ' + cmd) #HACK
 
 if args.temp:
     cli.remove_container(args.full_name, v=True, force=True)

--- a/dockersh
+++ b/dockersh
@@ -124,7 +124,7 @@ image_passed = (args.image != "")
 
 if args.temp:
     if not image_passed:
-        args.image = ini['image']
+        args.image = args.ini['image']
     args.image_base, args.image_tag = image_split(args.image)
     args.image = args.image_base + ':' + args.image_tag
     args.name = strip(args.image) + '_tmp' + random_string(4)


### PR DESCRIPTION
With this PR it is possible to

- pass non-tty commands over ssh, like
`ssh xyz echo hi`
- allow users to send and receive files into their own directory via:
`scp file xyz:.`
- let sudoers enter into their host-shell using
`ssh xyz admin`
