### PR TITLE
Volumes, Bugfixes (for rssh), admin-mode & Dockerfile-template 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ image = nvidia/cuda:latest
 homedir  = /somewhere/myuser1
 ```
 
+### Permission Errors - or: Make Container User = Host User
+By default, docker runs as root, hence in the container, the home-directory of the user will be not accessable by default and has to be chowned at first.
+After chowning, rssh will not work anymore, because it needs the home-directory to be chowned by the user himself.
+To prevent this problem due to permissions we encourage you to use the image template of this repository.
+
+1. Just type 
+```
+	./make_user_image.sh ubuntu_user ubuntu
+```
+to create a local image named 'ubuntu_user' that - together with dockersh - creates a user with the same uid and gid of the host user that runs `dockersh`.
+2. Change your `/etc/dockersh.ini` to use the `ubuntu_user`-image.
+
+**Note:** By default, it will overwrite the entrypoint of the 'cloned' image.
+
+
 ### Backup
 The home directory of the user is mounted inside of the container and can be used to store data persistently.
 However, since the container state is __non-persistent__, make sure you commit your running containers from time to time.

--- a/dockersh
+++ b/dockersh
@@ -124,9 +124,6 @@ ini = cfg[user] if cfg.has_section(user) else cfg['DEFAULT']
 #if __name__ == "__main__":
 args = parse_args()
 
-host_config = cli.create_host_config(binds=[args.home + ':/home/' + user],
-                                     restart_policy={'Name' : 'unless-stopped'})
-
 if args.cmd == admin_cmd:
     print("Trying to login into host: "+user)
     os.system("sudo -S su "+user+"; cd /home/"+user)
@@ -172,6 +169,17 @@ else:
 args.full_name = args.name + args.suffix
 
 if len(containers(container_filter=args.name)) == 0:
+    volumes = [args.home+':/home/'+user+':rw']
+    if "volumes" in args.ini:
+        volumes = volumes + args.ini["volumes"].split(",")
+    volumes = [v.split(":") for v in volumes]
+    binds = {v[1].strip():{"bind":v[0].strip(),"mode":v[2].strip()} for v in volumes}
+    volumes = [v[1] for v in volumes]
+
+    host_config = cli.create_host_config(#binds=[args.home + ':/home/' + user],
+        binds=binds,
+        restart_policy={'Name' : 'unless-stopped'})
+
     #cli.pull(args.image)
     cli.create_container(args.image,
                          stdin_open=True,
@@ -180,14 +188,15 @@ if len(containers(container_filter=args.name)) == 0:
                          command=args.shell,
                          hostname=args.name,
                          labels={'group': prog, 'user': user},
-                         volumes=['/home/'+user],
+                         volumes=volumes,
                          working_dir='/home/'+user,
-                         host_config=host_config)
+                         host_config=host_config
+                         )
 
 cli.start(args.full_name)
 print(args.greeting)
 cmd = args.cmd if args.cmd else args.shell
-#cli.attach(cfg.name, stream=True) #BUG https://github.com/docker/docker-py/issues/390
+#cli.attach(args.name, stream=True) #BUG https://github.com/docker/docker-py/issues/390
 docker_arg = "" if not sys.stdout.isatty() else "-it"
 os.system('docker exec ' + docker_arg +' '+ args.full_name + ' ' + cmd) #HACK
 

--- a/dockersh
+++ b/dockersh
@@ -126,14 +126,18 @@ args = parse_args()
 
 host_config = cli.create_host_config(binds=[args.home + ':/home/' + user],
                                      restart_policy={'Name' : 'unless-stopped'})
-if os.path.basename(args.cmd.split(" ")[0]).startswith(("scp -p","rsync --server","sftp-server")):
-    os.system("rssh -c \""+args.cmd+"\"")
-    sys.exit(0)
+
 if args.cmd == admin_cmd:
     print("Trying to login into host: "+user)
-    os.system("sudo -u "+user+" su - "+user)
+    os.system("sudo -S su "+user+"; cd /home/"+user)
     sys.exit(0)
 
+
+if args.cmd:
+    cmd_splits = args.cmd.split(" ",1)
+    if (os.path.basename(cmd_splits[0])+cmd_splits[1]).startswith(("scp -p","rsync --server","sftp-server")):
+        os.system("rssh -c \""+args.cmd+"\"")
+        sys.exit(0)
 name_passed  = (args.name  != "")
 image_passed = (args.image != "")
 

--- a/dockersh
+++ b/dockersh
@@ -138,7 +138,7 @@ if args.cmd == admin_cmd:
 
 if args.cmd:
     cmd_splits = args.cmd.split(" ",1)
-    if (os.path.basename(cmd_splits[0])+" "+cmd_splits[1]).startswith(("scp -p","rsync --server","sftp-server")):
+    if len(cmd_splits) > 1 and (os.path.basename(cmd_splits[0])+" "+cmd_splits[1]).startswith(("scp -p","rsync --server","sftp-server")):
         os.system("rssh -c \""+args.cmd+"\"")
         sys.exit(0)
 name_passed  = (args.name  != "")
@@ -175,14 +175,14 @@ else:
 args.full_name = args.name + args.suffix
 
 if len(containers(container_filter=args.name)) == 0:
-    volumes = [args.home+':/home/'+user+':rw']
+    volumes = []
     if "volumes" in args.ini:
         volumes = volumes + args.ini["volumes"].split(",")
     volumes = [v.split(":") for v in volumes]
-    binds = {v[1].strip():{"bind":v[0].strip(),"mode":v[2].strip()} for v in volumes}
+    binds = {v[0].strip():{"bind":v[1].strip(),"mode":v[2].strip()} for v in volumes}
     volumes = [v[1] for v in volumes]
 
-    host_config = cli.create_host_config(#binds=[args.home + ':/home/' + user],
+    host_config = cli.create_host_config(
         binds=binds,
         restart_policy={'Name' : 'unless-stopped'})
 
@@ -206,7 +206,10 @@ if len(containers(container_filter=args.name)) == 0:
 
 cli.start(args.full_name)
 print(args.greeting)
-user_bash = os.popen('docker exec '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
+user_bash = os.popen('docker exec -u root -it '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
+user_bash = ""
+if user_bash == "":
+    user_bash = "/bin/bash"
 cmd = args.cmd if args.cmd else user_bash
 docker_arg = "" if not sys.stdout.isatty() else "-it"
 os.system('docker exec -u '+user+ " " + docker_arg +' '+ args.full_name + ' ' + cmd)

--- a/dockersh
+++ b/dockersh
@@ -96,10 +96,6 @@ def parse_args():
                         dest='cmd',
                         help="pass command to bash in container",
                         default="")
-    parser.add_argument('--shell',
-                        dest='shell',
-                        help="shell to start inside the container",
-                        default=ini['shell'])
     parser.add_argument('--home',
                         dest='home',
                         help="user home directory",
@@ -119,10 +115,10 @@ cfg.read(config_file)
 
 admin_cmd = "admin"
 admin_shell = "/bin/bash"
-if cfg.has_section("ADMINS") and "command" in cfg["ADMINS"]:
-    admin_cmd = cfg["ADMINS"]["command"]
-    if "admin_shell" in cfg["ADMINS"]:
-        admin_shell = cfg["ADMINS"]["admin_shell"]
+if cfg.has_section("ADMIN") and "command" in cfg["ADMIN"]:
+    admin_cmd = cfg["ADMIN"]["command"]
+    if "admin_shell" in cfg["ADMIN"]:
+        admin_shell = cfg["ADMIN"]["admin_shell"]
 ini = cfg[user] if cfg.has_section(user) else cfg['DEFAULT']
 
 #if __name__ == "__main__":
@@ -196,7 +192,6 @@ if len(containers(container_filter=args.name)) == 0:
                          stdin_open=True,
                          tty=True,
                          name=args.full_name,
-                         command=args.shell,
                          hostname=args.name,
                          labels={'group': prog, 'user': user},
                          volumes=volumes,
@@ -211,11 +206,10 @@ if len(containers(container_filter=args.name)) == 0:
 
 cli.start(args.full_name)
 print(args.greeting)
-os.system('docker exec '+args.full_name + ' true') #HACK to start entrypoint (and user creation)
-cmd = args.cmd if args.cmd else args.shell
-#cli.attach(args.name, stream=True) #BUG https://github.com/docker/docker-py/issues/390
+user_bash = os.popen('docker exec '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
+cmd = args.cmd if args.cmd else user_bash
 docker_arg = "" if not sys.stdout.isatty() else "-it"
-os.system('docker exec -u '+user+ " " + docker_arg +' '+ args.full_name + ' ' + cmd) #HACK
+os.system('docker exec -u '+user+ " " + docker_arg +' '+ args.full_name + ' ' + cmd)
 
 if args.temp:
     cli.remove_container(args.full_name, v=True, force=True)

--- a/dockersh
+++ b/dockersh
@@ -201,6 +201,7 @@ if len(containers(container_filter=args.name)) == 0:
 
 cli.start(args.full_name)
 print(args.greeting)
+os.system('docker exec '+args.full_name + ' true') #HACK to start entrypoint (and user creation)
 cmd = args.cmd if args.cmd else args.shell
 #cli.attach(args.name, stream=True) #BUG https://github.com/docker/docker-py/issues/390
 docker_arg = "" if not sys.stdout.isatty() else "-it"

--- a/dockersh
+++ b/dockersh
@@ -118,8 +118,11 @@ cfg = ConfigParser(os.environ, interpolation=ExtendedInterpolation())
 cfg.read(config_file)
 
 admin_cmd = "admin"
-if cfg.has_section("ADMINS") and "command" in cfg["ADMINS"]["command"]:
+admin_shell = "/bin/bash"
+if cfg.has_section("ADMINS") and "command" in cfg["ADMINS"]:
     admin_cmd = cfg["ADMINS"]["command"]
+    if "admin_shell" in cfg["ADMINS"]:
+        admin_shell = cfg["ADMINS"]["admin_shell"]
 ini = cfg[user] if cfg.has_section(user) else cfg['DEFAULT']
 
 #if __name__ == "__main__":
@@ -133,7 +136,7 @@ if args.cmd == admin_cmd:
         print("Try login using:")
         print("ssh -t ...")
         sys.exit(0)
-    os.system("sudo su "+user+"; cd /home/"+user)
+    os.system("sudo -u "+user+" "+admin_shell)
     sys.exit(0)
 
 

--- a/dockersh
+++ b/dockersh
@@ -126,13 +126,19 @@ args = parse_args()
 
 if args.cmd == admin_cmd:
     print("Trying to login into host: "+user)
-    os.system("sudo -S su "+user+"; cd /home/"+user)
+    if not sys.stdout.isatty():
+        print()
+        print("admin mode is only possible using pseudo tty-allocation.")
+        print("Try login using:")
+        print("ssh -t ...")
+        sys.exit(0)
+    os.system("sudo su "+user+"; cd /home/"+user)
     sys.exit(0)
 
 
 if args.cmd:
     cmd_splits = args.cmd.split(" ",1)
-    if (os.path.basename(cmd_splits[0])+cmd_splits[1]).startswith(("scp -p","rsync --server","sftp-server")):
+    if (os.path.basename(cmd_splits[0])+" "+cmd_splits[1]).startswith(("scp -p","rsync --server","sftp-server")):
         os.system("rssh -c \""+args.cmd+"\"")
         sys.exit(0)
 name_passed  = (args.name  != "")
@@ -189,7 +195,7 @@ if len(containers(container_filter=args.name)) == 0:
                          hostname=args.name,
                          labels={'group': prog, 'user': user},
                          volumes=volumes,
-                         working_dir='/home/'+user,
+                         working_dir=args.home,
                          host_config=host_config
                          )
 

--- a/dockersh
+++ b/dockersh
@@ -11,6 +11,7 @@ import docker
 import random
 import string
 import sys
+from pwd import getpwnam
 
 prog = 'dockersh'
 version = prog + " v1.0"
@@ -187,6 +188,7 @@ if len(containers(container_filter=args.name)) == 0:
         restart_policy={'Name' : 'unless-stopped'})
 
     #cli.pull(args.image)
+    userpwd = getpwnam(user)
     cli.create_container(args.image,
                          stdin_open=True,
                          tty=True,
@@ -196,6 +198,11 @@ if len(containers(container_filter=args.name)) == 0:
                          labels={'group': prog, 'user': user},
                          volumes=volumes,
                          working_dir=args.home,
+                         environment={
+                            "HOST_USER_ID": userpwd.pw_uid,
+                            "HOST_USER_GID": userpwd.pw_gid,
+                            "HOST_USER_NAME": user
+                         },
                          host_config=host_config
                          )
 
@@ -205,7 +212,7 @@ os.system('docker exec '+args.full_name + ' true') #HACK to start entrypoint (an
 cmd = args.cmd if args.cmd else args.shell
 #cli.attach(args.name, stream=True) #BUG https://github.com/docker/docker-py/issues/390
 docker_arg = "" if not sys.stdout.isatty() else "-it"
-os.system('docker exec ' + docker_arg +' '+ args.full_name + ' ' + cmd) #HACK
+os.system('docker exec -u '+user+ " " + docker_arg +' '+ args.full_name + ' ' + cmd) #HACK
 
 if args.temp:
     cli.remove_container(args.full_name, v=True, force=True)

--- a/dockersh.ini
+++ b/dockersh.ini
@@ -1,5 +1,6 @@
-[ADMIN]
+[ADMINS]
 command = admin
+shell = /bin/bash
 
 [DEFAULT]
 image = ubuntu

--- a/dockersh.ini
+++ b/dockersh.ini
@@ -5,7 +5,6 @@ shell = /bin/bash
 [DEFAULT]
 image = ubuntu
 suffix = _${USER}
-shell = /bin/bash
 homedir = ${HOME}
 greeting = dockersh (github.com/sleeepyjack/dockersh)
 volumes = /globalinfo:/globalinfo:ro

--- a/dockersh.ini
+++ b/dockersh.ini
@@ -1,3 +1,6 @@
+[ADMIN]
+command = admin
+
 [DEFAULT]
 image = ubuntu
 suffix = _${USER}

--- a/dockersh.ini
+++ b/dockersh.ini
@@ -7,3 +7,4 @@ suffix = _${USER}
 shell = /bin/bash
 homedir = ${HOME}
 greeting = dockersh (github.com/sleeepyjack/dockersh)
+volumes = /globalinfo:/globalinfo:ro

--- a/image_template/Dockerfile
+++ b/image_template/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:latest
+
+COPY user-mapping.sh /
+RUN  chmod u+x /user-mapping.sh
+
+ENTRYPOINT ["/user-mapping.sh"]
+
+# docker build -t uiduntu . 
+# docker run --name uiduntu_myuser --rm -ti -e HOST_USER_ID=myuser -e HOST_USER_ID=22222 -e HOST_USER_GID=22222 uiduntu

--- a/image_template/user-mapping.sh
+++ b/image_template/user-mapping.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "${HOST_USER_NAME}" -o -z "${HOST_USER_ID}" -o -z "${HOST_USER_GID}" ]; then
+	echo "HOST_USER_NAME, HOST_USER_ID & HOST_USER_GID needs to be set!"; exit 100
+fi
+
+groupadd --gid "${HOST_USER_GID}" "${HOST_USER_NAME}"
+useradd \
+      --uid ${HOST_USER_ID} \
+      --gid ${HOST_USER_GID} \
+      --create-home \
+      --shell /bin/bash \
+      ${HOST_USER_NAME}
+usermod -aG sudo ${HOST_USER_NAME}
+
+echo ${HOST_USER_NAME}:${HOST_USER_NAME} | chpasswd
+
+exec su - "${HOST_USER_NAME}"

--- a/image_template/user-mapping.sh
+++ b/image_template/user-mapping.sh
@@ -4,13 +4,13 @@ if [ -z "${HOST_USER_NAME}" -o -z "${HOST_USER_ID}" -o -z "${HOST_USER_GID}" ]; 
 	echo "HOST_USER_NAME, HOST_USER_ID & HOST_USER_GID needs to be set!"; exit 100
 fi
 
-groupadd --gid "${HOST_USER_GID}" "${HOST_USER_NAME}"
 useradd \
       --uid ${HOST_USER_ID} \
       --gid ${HOST_USER_GID} \
       --create-home \
       --shell /bin/bash \
       ${HOST_USER_NAME}
+groupadd --gid "${HOST_USER_GID}" "${HOST_USER_NAME}"
 usermod -aG sudo ${HOST_USER_NAME}
 
 echo ${HOST_USER_NAME}:${HOST_USER_NAME} | chpasswd

--- a/make_user_image.sh
+++ b/make_user_image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -z "$1" -o -z "$2" ]; then
+	echo "./make_user_image.sh [name] [source-image]"; exit 100
+fi
+
+sed -i "1s/.*/FROM $2/" image_template/Dockerfile
+cd image_template
+docker build -t $1 .


### PR DESCRIPTION
This PR features
- **Volume-support**:
     - additional Volumes can be added to the dockersh.ini, e.g. for *global information & shared folders* for the users across the containers
- **Admin-Mode**:
     - last commit was missing the updated `dockersh.ini`
     - `ssh -t` is introduced, as `sudo -S` asks for the userpassword in plaintext-form
- **Dockerfile-template**:
     - to fix the problem of *file-permissions in a container vs on the host-machine*, a docker-template generates the host-user (with the same uid,gid-combo) in the docker-container at first run
     - a script helps at using any image to include this functionality
- **minor bugfixes**:
     - `Entrypoint` was not executed (at first boot) due to 'exec /bin/bash'-attach