### PR TITLE
scp into docker, quickfix (works randomly) for wrong window sizes in container

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,6 @@ will give you an interactive shell.
 - [Docker](https://docs.docker.com/install/)
 - [Python 3.x](https://www.python.org/downloads/)
 - [pip](https://pip.pypa.io/en/stable/installing/)
-- [rssh](http://www.pizzashack.org/rssh/)
-
-**To enable scp,rsync,sftp for all users, configure rssh as follows:**
-```
-sudo echo "
-allowscp
-allowsftp
-allowrsync
-" > /etc/rssh.conf
-```
 
 Make sure all `dockersh` users have the [permissions to interact with the Docker daemon](https://docs.docker.com/install/linux/linux-postinstall/).
 
@@ -84,8 +74,7 @@ homedir  = /somewhere/myuser1
 
 ### Permission Errors - or: Make Container User = Host User
 By default, docker runs as root, hence in the container, the home-directory of the user will be not accessable by default and has to be chowned at first.
-After chowning, rssh will not work anymore, because it needs the home-directory to be chowned by the user himself.
-To prevent this problem due to permissions we encourage you to use the image template of this repository.
+To prevent this problem due to permissions we encourage you to use the image template of this repository, that maps the internal docker-user to the host-user.
 
 1. Just type 
 ```

--- a/dockersh
+++ b/dockersh
@@ -17,7 +17,9 @@ prog = 'dockersh'
 version = prog + " v1.0"
 config_file = "/etc/dockersh.ini"
 
-user = os.environ['USER']
+import getpass
+user = getpass.getuser()
+
 host = os.uname()[1]
 
 cli = docker.APIClient()
@@ -110,7 +112,10 @@ def parse_args():
 
 
 # load ini
-cfg = ConfigParser(os.environ, interpolation=ExtendedInterpolation())
+config_envir = {
+    "USER": user
+}
+cfg = ConfigParser(config_envir, interpolation=ExtendedInterpolation())
 cfg.read(config_file)
 
 admin_cmd = "admin"
@@ -140,6 +145,8 @@ is_scp_cmd = False
 if args.cmd:
     if os.path.basename(args.cmd).startswith(("scp","rsync --server","sftp-server","ls")):
         is_scp_cmd = True
+    if args.cmd == "envir":
+        print(os.environ)
 name_passed  = (args.name  != "")
 image_passed = (args.image != "")
 

--- a/dockersh
+++ b/dockersh
@@ -180,6 +180,7 @@ else:
 
 args.full_name = args.name + args.suffix
 
+initing = False
 if len(containers(container_filter=args.name)) == 0:
     volumes = []
     if "volumes" in args.ini:
@@ -209,8 +210,12 @@ if len(containers(container_filter=args.name)) == 0:
                          },
                          host_config=host_config
                          )
+    initing=True
 
 cli.start(args.full_name)
+if initing:
+    print("Initializing container ...")
+    os.popen('docker exec '+args.full_name + ' echo Initialization finished.').read().split(":")[-1]
 if len(args.cmd) == 0:
     print(args.greeting)
 user_bash = os.popen('docker exec -u root '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]

--- a/dockersh
+++ b/dockersh
@@ -138,7 +138,7 @@ if args.cmd == admin_cmd:
 
 is_scp_cmd = False
 if args.cmd:
-    if os.path.basename(args.cmd).startswith(("scp","rsync --server","sftp-server")):
+    if os.path.basename(args.cmd).startswith(("scp","rsync --server","sftp-server","ls")):
         is_scp_cmd = True
 name_passed  = (args.name  != "")
 image_passed = (args.image != "")
@@ -204,7 +204,7 @@ if len(containers(container_filter=args.name)) == 0:
                          )
 
 cli.start(args.full_name)
-if not is_scp_cmd:
+if len(args.cmd) == 0:
     print(args.greeting)
 user_bash = os.popen('docker exec -u root '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
 if user_bash == "":
@@ -214,7 +214,7 @@ cmd = args.cmd if args.cmd else user_bash
 # only sometimes working hotfix for https://github.com/moby/moby/issues/35407
 if not is_scp_cmd:
     cmd = "/bin/bash -c \"sleep 0.1 && " + cmd + "\""
-
+ 
 # a tty needs -it, scp needs -i
 docker_arg = "-i" if not sys.stdout.isatty() or is_scp_cmd else "-it"
 os.system('docker exec -u '+user+" " + docker_arg +' '+ args.full_name + ' ' + cmd)

--- a/dockersh
+++ b/dockersh
@@ -137,8 +137,7 @@ if args.cmd == admin_cmd:
 
 
 if args.cmd:
-    cmd_splits = args.cmd.split(" ",1)
-    if len(cmd_splits) > 1 and (os.path.basename(cmd_splits[0])+" "+cmd_splits[1]).startswith(("scp -p","rsync --server","sftp-server")):
+    if os.path.basename(args.cmd).startswith(("scp","rsync --server","sftp-server")):
         os.system("rssh -c \""+args.cmd+"\"")
         sys.exit(0)
 name_passed  = (args.name  != "")

--- a/dockersh
+++ b/dockersh
@@ -210,8 +210,9 @@ user_bash = ""
 if user_bash == "":
     user_bash = "/bin/bash"
 cmd = args.cmd if args.cmd else user_bash
+cmd = "sleep 0.1 && " + cmd
 docker_arg = "" if not sys.stdout.isatty() else "-it"
-os.system('docker exec -u '+user+ " -it " + docker_arg +' '+ args.full_name + ' ' + cmd)
+os.system('docker exec -u '+user+ " " + docker_arg +' '+ args.full_name + ' ' + cmd)
 
 if args.temp:
     cli.remove_container(args.full_name, v=True, force=True)

--- a/dockersh
+++ b/dockersh
@@ -205,13 +205,13 @@ if len(containers(container_filter=args.name)) == 0:
 
 cli.start(args.full_name)
 print(args.greeting)
-user_bash = os.popen('docker exec -u root -it '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
+user_bash = os.popen('docker exec -u root '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
 user_bash = ""
 if user_bash == "":
     user_bash = "/bin/bash"
 cmd = args.cmd if args.cmd else user_bash
 docker_arg = "" if not sys.stdout.isatty() else "-it"
-os.system('docker exec -u '+user+ " " + docker_arg +' '+ args.full_name + ' ' + cmd)
+os.system('docker exec -u '+user+ " -it " + docker_arg +' '+ args.full_name + ' ' + cmd)
 
 if args.temp:
     cli.remove_container(args.full_name, v=True, force=True)

--- a/dockersh
+++ b/dockersh
@@ -17,8 +17,8 @@ prog = 'dockersh'
 version = prog + " v1.0"
 config_file = "/etc/dockersh.ini"
 
-import getpass
-user = getpass.getuser()
+import os
+user = os.getlogin()
 
 host = os.uname()[1]
 

--- a/dockersh
+++ b/dockersh
@@ -136,10 +136,10 @@ if args.cmd == admin_cmd:
     sys.exit(0)
 
 
+is_scp_cmd = False
 if args.cmd:
     if os.path.basename(args.cmd).startswith(("scp","rsync --server","sftp-server")):
-        os.system("rssh -c \""+args.cmd+"\"")
-        sys.exit(0)
+        is_scp_cmd = True
 name_passed  = (args.name  != "")
 image_passed = (args.image != "")
 
@@ -204,15 +204,20 @@ if len(containers(container_filter=args.name)) == 0:
                          )
 
 cli.start(args.full_name)
-print(args.greeting)
+if not is_scp_cmd:
+    print(args.greeting)
 user_bash = os.popen('docker exec -u root '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
-user_bash = ""
 if user_bash == "":
     user_bash = "/bin/bash"
 cmd = args.cmd if args.cmd else user_bash
-cmd = "sleep 0.1 && " + cmd
-docker_arg = "" if not sys.stdout.isatty() else "-it"
-os.system('docker exec -u '+user+ " " + docker_arg +' '+ args.full_name + ' ' + cmd)
+
+# only sometimes working hotfix for https://github.com/moby/moby/issues/35407
+if not is_scp_cmd:
+    cmd = "/bin/bash -c \"sleep 0.1 && " + cmd + "\""
+
+# a tty needs -it, scp needs -i
+docker_arg = "-i" if not sys.stdout.isatty() or is_scp_cmd else "-it"
+os.system('docker exec -u '+user+" " + docker_arg +' '+ args.full_name + ' ' + cmd)
 
 if args.temp:
     cli.remove_container(args.full_name, v=True, force=True)


### PR DESCRIPTION
This PR includes:
- scp into docker containers, thus `rssh` is not needed anymore
- a randomly working quickfix (`sleep 0.1 &&`) for a bug that shows vim in wrong dimensions (see: https://github.com/moby/moby/issues/35407 ). This seems to be a docker-related bug. Until this is solved, the user has to refresh the window, e.g. by resizing.
- bugfix that puts user into root if executed with sudo