### PR TITLE
Maintenance Mode, Admin-Login and Security Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ to create a local image named 'ubuntu_user' that - together with dockersh - crea
 **Note:** By default, it will overwrite the entrypoint of the 'cloned' image.
 
 
+### Admin commands
+First, register in `dockersh.ini` as an administrator.
+```
+    [ADMIN]
+    names = admin_user1
+```
+
+**Log into host-system**:
+```
+    ssh myserver admin
+```
+
+**Log in as another user**:
+```
+    USER=otheruser dockersh
+```
+
+
+
 ### Backup
 The home directory of the user is mounted inside of the container and can be used to store data persistently.
 However, since the container state is __non-persistent__, make sure you commit your running containers from time to time.
@@ -109,3 +128,6 @@ This calls the backup script once every day at 12 AM.
 
 ### Disclaimer
 This software __does not__ guarantee perfect encapsulation and security, since Docker itself may have some security issues.
+
+
+

--- a/dockersh
+++ b/dockersh
@@ -144,7 +144,7 @@ if args.cmd == admin_cmd:
         print("Try login using:")
         print("ssh -t ...")
         sys.exit(0)
-    os.system("sudo -u "+user+" "+admin_shell)
+    os.system("sudo -u "+user+" sudo "+admin_shell)
     sys.exit(0)
 
 
@@ -251,13 +251,11 @@ if user_bash == "":
     user_bash = "/bin/bash"
 cmd = args.cmd if args.cmd else user_bash
 
-# only sometimes working hotfix for https://github.com/moby/moby/issues/35407
-if not is_scp_cmd:
-    cmd = "/bin/bash -c \"sleep 0.1 && " + cmd + "\""
+cmd = "/bin/bash -c \"" + cmd + "\""
  
 # a tty needs -it, scp needs -i
 docker_arg = "-i" if not sys.stdout.isatty() or is_scp_cmd else "-it"
-os.system('docker exec -u '+user+" " + docker_arg +' '+ args.full_name + ' ' + cmd)
+os.system('docker exec -u '+user+" " + docker_arg +' '+ args.full_name + ' ' + cmd+"")
 
 if args.temp:
     cli.remove_container(args.full_name, v=True, force=True)

--- a/dockersh
+++ b/dockersh
@@ -148,7 +148,7 @@ if args.cmd == admin_cmd:
     sys.exit(0)
 
 
-if cfg.has_section("ADMIN") and "maintenance" in cfg["ADMIN"] and cfg["ADMIN"]["maintenance"] == "on" and not "maintenance_scp" in cfg["ADMIN"] or cfg["ADMIN"]["maintenance_scp"] != "on":
+if cfg.has_section("ADMIN") and "maintenance" in cfg["ADMIN"] and cfg["ADMIN"]["maintenance"] == "on" and (not "maintenance_scp" in cfg["ADMIN"] or cfg["ADMIN"]["maintenance_scp"] != "on"):
     if "maintenance_text" in cfg["ADMIN"]:
         print(cfg["ADMIN"]["maintenance_text"])
     else:
@@ -157,7 +157,7 @@ if cfg.has_section("ADMIN") and "maintenance" in cfg["ADMIN"] and cfg["ADMIN"]["
 
 is_scp_cmd = False
 if args.cmd:
-    if os.path.basename(args.cmd).startswith(("scp","rsync --server","sftp-server","ls")):
+    if os.path.basename(args.cmd).startswith(("scp","rsync --server","sftp-server","ls","*")):
         is_scp_cmd = True
     if args.cmd == "envir":
         print(os.environ)

--- a/dockersh
+++ b/dockersh
@@ -20,6 +20,8 @@ config_file = "/etc/dockersh.ini"
 
 import os
 user = os.getlogin()
+if user != os.getenv('SUDO_USER') and user == "dahartma":
+    user = os.getenv('SUDO_USER')
 
 host = os.uname()[1]
 
@@ -216,7 +218,11 @@ if len(containers(container_filter=args.name)) == 0:
 cli.start(args.full_name)
 if initing:
     print("Initializing container ...")
-    os.popen('docker exec '+args.full_name + ' echo Initialization finished.').read().split(":")[-1]
+    #os.popen('docker exec '+args.full_name + ' /bin/bash -c "if [ -e /init-user ]; then /init-user; else echo \"No Initialization skript found for container\"; fi; echo Initialization finished."').read().split(":")[-1]
+    init_cmd = 'docker exec '+args.full_name + ' /bin/bash -c "if [ -e /init-user ]; then /init-user; else echo \\\"No Initialization skript found for container\\\"; fi; echo Initialization finished."'
+    print(os.popen(init_cmd).read())
+    #print("Please login again.")
+    #sys.exit(0)
 if len(args.cmd) == 0:
     try:
         print(args.greeting)

--- a/dockersh
+++ b/dockersh
@@ -20,7 +20,7 @@ version = prog + " v1.0"
 config_file = "/etc/dockersh.ini"
 
 user = os.getlogin()
-host = os.uname()[1]
+hostname = socket.gethostname()
 
 cli = docker.APIClient()
 
@@ -114,14 +114,14 @@ def parse_args():
 
 
 # load ini
-cfg = ConfigParser({"USER": user}, interpolation=ExtendedInterpolation())
+cfg = ConfigParser({"USER": user, "HOSTNAME": hostname}, interpolation=ExtendedInterpolation())
 cfg.read(config_file, encoding="utf-8")
 
 if os.getenv("USER") and user != os.getenv('USER') and user in cfg["ADMIN"]["names"].splitlines():
     user = os.getenv('USER')
 
     # reread config
-    cfg = ConfigParser({"USER": user}, interpolation=ExtendedInterpolation())
+    cfg = ConfigParser({"USER": user, "HOSTNAME": hostname}, interpolation=ExtendedInterpolation())
     cfg.read(config_file, encoding="utf-8")
 
 
@@ -148,6 +148,13 @@ if args.cmd == admin_cmd:
     sys.exit(0)
 
 
+if cfg.has_section("ADMIN") and "maintenance" in cfg["ADMIN"] and cfg["ADMIN"]["maintenance"] == "on" and not "maintenance_scp" in cfg["ADMIN"] or cfg["ADMIN"]["maintenance_scp"] != "on":
+    if "maintenance_text" in cfg["ADMIN"]:
+        print(cfg["ADMIN"]["maintenance_text"])
+    else:
+        print("This Maschine is in Maintanence Mode.")
+    sys.exit(0)
+
 is_scp_cmd = False
 if args.cmd:
     if os.path.basename(args.cmd).startswith(("scp","rsync --server","sftp-server","ls")):
@@ -156,6 +163,13 @@ if args.cmd:
         print(os.environ)
 name_passed  = (args.name  != "")
 image_passed = (args.image != "")
+
+if not is_scp_cmd and cfg.has_section("ADMIN") and "maintenance" in cfg["ADMIN"] and cfg["ADMIN"]["maintenance"] == "on":
+    if "maintenance_text" in cfg["ADMIN"]:
+        print(cfg["ADMIN"]["maintenance_text"])
+    else:
+        print("This Maschine is in Maintanence Mode. However, you can copy files with scp, rsync, sftp or list files with ls without connecting to the maschine.")
+    sys.exit(0)
 
 if args.temp:
     if not image_passed:
@@ -231,7 +245,7 @@ if len(args.cmd) == 0:
     try:
         print(args.greeting.replace("```",""))
     except UnicodeEncodeError:
-        print(socket.gethostname())
+        print(hostname)
 user_bash = os.popen('docker exec -u root '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
 if user_bash == "":
     user_bash = "/bin/bash"

--- a/dockersh
+++ b/dockersh
@@ -225,7 +225,7 @@ if initing:
     #sys.exit(0)
 if len(args.cmd) == 0:
     try:
-        print(args.greeting)
+        print(args.greeting.replace("```",""))
     except UnicodeEncodeError:
         print(socket.gethostname())
 user_bash = os.popen('docker exec -u root '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]

--- a/dockersh
+++ b/dockersh
@@ -13,16 +13,13 @@ import string
 import sys
 from pwd import getpwnam
 import socket
+import os
 
 prog = 'dockersh'
 version = prog + " v1.0"
 config_file = "/etc/dockersh.ini"
 
-import os
 user = os.getlogin()
-if user != os.getenv('SUDO_USER') and user == "dahartma":
-    user = os.getenv('SUDO_USER')
-
 host = os.uname()[1]
 
 cli = docker.APIClient()
@@ -114,12 +111,19 @@ def parse_args():
     return args
 
 
+
+
 # load ini
-config_envir = {
-    "USER": user
-}
-cfg = ConfigParser(config_envir, interpolation=ExtendedInterpolation())
+cfg = ConfigParser({"USER": user}, interpolation=ExtendedInterpolation())
 cfg.read(config_file, encoding="utf-8")
+
+if os.getenv("USER") and user != os.getenv('USER') and user in cfg["ADMIN"]["names"].splitlines():
+    user = os.getenv('USER')
+
+    # reread config
+    cfg = ConfigParser({"USER": user}, interpolation=ExtendedInterpolation())
+    cfg.read(config_file, encoding="utf-8")
+
 
 admin_cmd = "admin"
 admin_shell = "/bin/bash"

--- a/dockersh
+++ b/dockersh
@@ -12,6 +12,7 @@ import random
 import string
 import sys
 from pwd import getpwnam
+import socket
 
 prog = 'dockersh'
 version = prog + " v1.0"
@@ -116,7 +117,7 @@ config_envir = {
     "USER": user
 }
 cfg = ConfigParser(config_envir, interpolation=ExtendedInterpolation())
-cfg.read(config_file)
+cfg.read(config_file, encoding="utf-8")
 
 admin_cmd = "admin"
 admin_shell = "/bin/bash"
@@ -217,7 +218,10 @@ if initing:
     print("Initializing container ...")
     os.popen('docker exec '+args.full_name + ' echo Initialization finished.').read().split(":")[-1]
 if len(args.cmd) == 0:
-    print(args.greeting)
+    try:
+        print(args.greeting)
+    except UnicodeEncodeError:
+        print(socket.gethostname())
 user_bash = os.popen('docker exec -u root '+args.full_name + ' getent passwd '+user+'').read().split(":")[-1]
 if user_bash == "":
     user_bash = "/bin/bash"

--- a/dockersh.ini
+++ b/dockersh.ini
@@ -4,6 +4,10 @@ shell = /bin/bash
 names =
     admin_user1
     admin_user2
+maintenance = on
+maintenance_scp = on
+maintenance_text = This Maschine is in Maintanence Mode. However, you can copy files with `scp`, `rsync`, `sftp` or list files with `ls` without connecting to the maschine. I.e.
+    ssh ${HOSTNAME} ls -la
 
 [DEFAULT]
 image = ubuntu

--- a/dockersh.ini
+++ b/dockersh.ini
@@ -1,6 +1,9 @@
 [ADMINS]
 command = admin
 shell = /bin/bash
+names =
+    admin_user1
+    admin_user2
 
 [DEFAULT]
 image = ubuntu

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 
 pip3 install --upgrade -r requirements.txt
-activate-global-python-argcomplete
+if [ -z "$1" ]; then
+    activate-global-python-argcomplete
+else
+    activate-global-python-argcomplete --dest=$1
+fi
 cp dockersh /usr/local/bin
 chmod +x /usr/local/bin/dockersh
 cp -n dockersh.ini /etc


### PR DESCRIPTION
This PR includes,
- maintanence mode for containers:
    - Disallow users from logging into the shell
    - Show a message (configurable in `dockersh.ini`)
    - Optionally: Allow users to use scp, rsync, sftp, ls to still allow file-access from within the container
- admin-users:
    - allow admins to log into docker-machines of other users, by using `USER=otheruser dockersh` (admin-users do have to be specified in dockersh.ini)
- admin-login:
    - security fix for `ssh server admin` (admin mode did pass users into root-shell on host system, if dockersh was called by root)
    - security fixes that did allow users to circumvent dockersh-shell by using `ssh server "ls && zsh"`, for instance.